### PR TITLE
Change indentify for user from "name" to "alias"

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ zbx.users.create(
 
 ### Update user
 ```ruby
-zbx.users.update(:userid => zbx.users.get_id(:name => "user"), :name => "user2")
+zbx.users.update(:userid => zbx.users.get_id(:alias => "user"), :name => "user2")
 ```
 
 ### Delete graph
@@ -286,7 +286,7 @@ zbx.screens.delete(
 zbx.usergroups.get_or_create(:name => "Some user group")
 zbx.usergroups.add_user(
   :usrgrpids => [zbx.usergroups.get_id(:name => "Some user group")],
-  :userids => [zbx.users.get_id(:name => "Some user")]
+  :userids => [zbx.users.get_id(:alias => "user")]
 )
 # set write and read permissions for UserGroup on all hostgroups
 zbx.usergroups.set_perm(
@@ -305,7 +305,7 @@ zbx.mediatypes.create_or_update(
   :smtp_email => "zabbix@test.com"
 )
 zbx.users.add_medias(
-  :userids => [zbx.users.get_id(:name => "user")],
+  :userids => [zbx.users.get_id(:alias => "user")],
   :media => [
     {
       :mediatypeid => zbx.mediatypes.get_id(:description => "mediatype"),

--- a/lib/zabbixapi/classes/users.rb
+++ b/lib/zabbixapi/classes/users.rb
@@ -14,7 +14,7 @@ class ZabbixApi
     end
 
     def indentify
-      "name"
+      "alias"
     end
 
     def add_medias(data)

--- a/spec/user.rb
+++ b/spec/user.rb
@@ -21,7 +21,7 @@ describe 'user' do
       it "should return integer id" do
         user = gen_name 'user'
         userid = zbx.users.create(
-          :alias => "Test #{user}",
+          :alias => user,
           :name => user,
           :surname => user,
           :passwd => user,
@@ -33,7 +33,7 @@ describe 'user' do
 
     describe 'get_id' do
       it "should return nil" do
-        zbx.users.get_id(:name => "name_____").should be_nil
+        zbx.users.get_id(:alias => "name_____").should be_nil
       end
     end
   end
@@ -63,7 +63,7 @@ describe 'user' do
 
     describe 'get_full_data' do
       it "should return string name" do
-        zbx.users.get_full_data(:name => @user)[0]['name'].should be_kind_of(String)
+        zbx.users.get_full_data(:alias => @user)[0]['name'].should be_kind_of(String)
       end
     end
 


### PR DESCRIPTION
For the user object the "name" key corresponds to the "first name" field and is not unique.  Alias is a unique key corresponding to uid/username and is what is used for login, so it is the appropriate search criteria for the user object.
