### PR TITLE
Add function to mass update a usergroup

### DIFF
--- a/lib/zabbixapi/classes/usergroups.rb
+++ b/lib/zabbixapi/classes/usergroups.rb
@@ -66,5 +66,22 @@ class ZabbixApi
       result ? result['usrgrpids'][0].to_i : nil
     end
 
+    # Update usergroup, modify users
+    # 
+    # * *Args*    :
+    #   - +data+ -> Hash with :usrgrpids => id, :userids => []
+    # * *Returns* :
+    #   - Integer
+    def update_users(data)
+      result = @client.api_request(
+        :method => "usergroup.massUpdate", 
+        :params => {
+          :usrgrpids => data[:usrgrpids],
+          :userids => data[:userids]
+        }
+      )
+      result ? result['usrgrpids'][0].to_i : nil
+    end
+
   end
 end

--- a/spec/usergroup.rb
+++ b/spec/usergroup.rb
@@ -50,6 +50,15 @@ describe 'usergroup' do
       end
     end
 
+    describe 'update_users' do
+      it "should return id" do
+        zbx.usergroups.update_users(
+            :usrgrpids => [@usergroupid],
+            :userids => [@userid2]
+        ).should eq @usergroupid
+      end
+    end
+
     describe 'set_perms' do
       it "should return id" do
         zbx.usergroups.set_perms(


### PR DESCRIPTION
New usergroup.update_users takes the same parameters as usergroup.add_user but calls massUpdate rather than massAdd so that users are added/removed as necessary to match the new membership list.  I use this function to synchronize an LDAP group with a Zabbix group.
