### PR TITLE
use ssl if uri.scheme == https, not if port is 443

### DIFF
--- a/lib/zabbixapi/client.rb
+++ b/lib/zabbixapi/client.rb
@@ -56,7 +56,7 @@ class ZabbixApi
       unless @proxy_uri.nil?
         http = Net::HTTP.Proxy(@proxy_host, @proxy_port, @proxy_user, @proxy_pass).new(uri.host, uri.port)
 
-        if uri.port == 443
+        if uri.scheme == 'https'
           http.use_ssl = true
           http.verify_mode = OpenSSL::SSL::VERIFY_NONE
         end


### PR DESCRIPTION
Hello,

I came across this while running a Zabbix instance in Vagrant; use_ssl is set to true only when the port is 443.  This fix sets it to true when uri.scheme == https.
