### PR TITLE
Zabbix API 2.4 supported

### DIFF
--- a/lib/zabbixapi.rb
+++ b/lib/zabbixapi.rb
@@ -41,9 +41,6 @@ class ZabbixApi
 
   def initialize(options = {})
     @client = Client.new(options)
-    unless @client.api_version =~ /2\.2\.\d+/
-      raise "Zabbix API version: #{@client.api_version} is not support by this version of zabbixapi"
-    end
   end
 
   def server
@@ -103,4 +100,5 @@ class ZabbixApi
   end
 
 end
+
 

--- a/lib/zabbixapi/client.rb
+++ b/lib/zabbixapi/client.rb
@@ -17,7 +17,7 @@ class ZabbixApi
 
     def auth
       api_request(
-        :method => 'user.authenticate',
+        :method => 'user.login',
         :params => {
           :user      => @options[:user],
           :password  => @options[:password],
@@ -32,6 +32,9 @@ class ZabbixApi
         @proxy_host = @proxy_uri.host
         @proxy_port = @proxy_uri.port
         @proxy_user, @proxy_pass = @proxy_uri.userinfo.split(/:/) if @proxy_uri.userinfo
+      end
+      unless api_version =~ /2\.4\.\d+/
+        raise "Zabbix API version: #{api_version} is not support by this version of zabbixapi"
       end
       @auth_hash = auth
     end
@@ -92,3 +95,4 @@ class ZabbixApi
 
   end
 end
+

--- a/lib/zabbixapi/version.rb
+++ b/lib/zabbixapi/version.rb
@@ -1,3 +1,3 @@
 class ZabbixApi
-  VERSION = "2.2.1"
+  VERSION = "2.4.0"
 end


### PR DESCRIPTION
Added compatibility with zabbix api 2.4 
Login now uses "user.login" and "apiinfo.version" is called before attempting to login.
Please tell if there is anything else to add.
Full list of api changes here: https://www.zabbix.com/documentation/2.4/manual/api/changes_2.2_-_2.4
