### PR TITLE
Extending get_full_data and adding Hostinterfaces api

### DIFF
--- a/lib/zabbixapi.rb
+++ b/lib/zabbixapi.rb
@@ -23,6 +23,7 @@ require "zabbixapi/classes/usergroups"
 require "zabbixapi/classes/usermacros"
 require "zabbixapi/classes/users"
 require "zabbixapi/classes/configurations"
+require "zabbixapi/classes/hostinterfaces"
 
 class ZabbixApi
 
@@ -107,5 +108,8 @@ class ZabbixApi
     @configurations ||= Configurations.new(@client)
   end
 
+  def hostinterfaces
+    @hostinterfaces ||= Hostinterfaces.new(@client)
+  end
 end
 

--- a/lib/zabbixapi/basic/basic_logic.rb
+++ b/lib/zabbixapi/basic/basic_logic.rb
@@ -46,22 +46,25 @@ class ZabbixApi
     end
 
     def get_full_data(data)
-      log "[DEBUG] Call get_full_data with parametrs: #{data.inspect}"
+      log "[DEBUG] Call get_full_data with parametrs: #{data.inspect} and params #{data[:params]}"
 
-      @client.api_request(
+      data[:params] ||= {}
+      res = @client.api_request(
         :method => "#{method_name}.get",
         :params => {
           :filter => {
             indentify.to_sym => data[indentify.to_sym]
           },
           :output => "extend"
-        }
+        }.merge(data[:params])
       )
+      res
     end
 
     def dump_by_id(data)
-      log "[DEBUG] Call dump_by_id with parametrs: #{data.inspect}"
+      log "[DEBUG] Call dump_by_id with parametrs: #{data.inspect} and params #{data[:params]}"
 
+      data[:params] ||= {}
       @client.api_request(
         :method => "#{method_name}.get",
         :params => {
@@ -69,7 +72,7 @@ class ZabbixApi
             key.to_sym => data[key.to_sym]
           },
           :output => "extend"
-        }
+        }.merge(data[:params])
       )
     end
 

--- a/lib/zabbixapi/classes/hostinterfaces.rb
+++ b/lib/zabbixapi/classes/hostinterfaces.rb
@@ -1,0 +1,19 @@
+class ZabbixApi
+  class Hostinterfaces < Basic
+    def array_flag
+      true
+    end
+
+    def method_name
+      "hostinterface"
+    end
+
+    def indentify
+      "hostid"
+    end
+
+    def key
+      "interfaceid"
+    end
+  end
+end

--- a/lib/zabbixapi/version.rb
+++ b/lib/zabbixapi/version.rb
@@ -1,3 +1,3 @@
 class ZabbixApi
-  VERSION = "2.2.1"
+  VERSION = "2.2.3"
 end

--- a/spec/host.rb
+++ b/spec/host.rb
@@ -36,15 +36,15 @@ describe 'host' do
         @hostgroupid2 = zbx.hostgroups.create(:name => gen_name('hostgroup'))
         host = gen_name('host')
         hostid = zbx.hosts.create(
-          host: host,
-          interfaces: [{ type: 1, main: 1, ip: '192.168.0.1', dns: 'server.example.org', port: 10050, useip: 0 }],
-          groups: [
-            {groupid: @hostgroupid},
-            {groupid: @hostgroupid2}
+          :host => host,
+          :interfaces => [{ :type => 1, :main => 1, :ip => '192.168.0.1', :dns => 'server.example.org', :port => 10050, :useip => 0 }],
+          :groups => [
+            {:groupid => @hostgroupid},
+            {:groupid => @hostgroupid2}
           ])
 
         expect(hostid).to be_kind_of Integer
-        host = zbx.query(method: 'host.get', params: { hostids: [hostid], selectGroups: 'extend' }).first
+        host = zbx.query(:method => 'host.get', :params => { :hostids => [hostid], :selectGroups => 'extend' }).first
 
         expect(host['hostid'].to_i).to eq hostid
         expect(host['groups'].size).to eq 2
@@ -89,6 +89,11 @@ describe 'host' do
     describe 'get_full_data' do
       it "should contains created host" do
         expect(zbx.hosts.get_full_data(:host => @host)[0]).to include("host" => @host)
+      end
+
+      it "shoulld dump interfaces" do
+        expect(zbx.hosts.get_full_data(:host => @host, :params => {:selectInterfaces => "extend"})[0]["interfaces"][0]).to include("type" => "1")
+        expect(zbx.hosts.get_full_data(:host => @host, :params => {:selectInterfaces => "extend"})[0]["interfaces"][0]).to include("ip" => "10.20.48.88")
       end
     end
 

--- a/spec/hostinterface.rb
+++ b/spec/hostinterface.rb
@@ -1,0 +1,79 @@
+#encoding: utf-8
+
+require 'spec_helper'
+
+describe "hostinterface" do
+  before :all do
+    @hostgroup = gen_name 'hostgroup'
+    @hostgroupid = zbx.hostgroups.create(:name => @hostgroup)
+  end
+
+  context 'when interface not exists' do
+    before do
+      @host = gen_name 'host'
+    end
+
+    describe 'create' do
+      it 'should return integer id' do
+        @hostid = zbx.hosts.create(:host => @host,
+                                   :interfaces => [
+                                       {
+                                           :type => 1,
+                                           :main => 1,
+                                           :ip => "10.20.48.88",
+                                           :dns => "",
+                                           :port => 10050,
+                                           :useip => 1
+                                       }
+                                   ],
+                                   :groups => [:groupid => @hostgroupid]
+        )
+        interfaceid = zbx.hostinterfaces.create(
+            :hostid => @hostid,
+            :dns => "",
+            :ip => "1.1.1.1",
+            :main => 0,
+            :port => '10050',
+            :type => 1,
+            :useip => 1
+        )
+        interfaceid.should be_kind_of(Integer)
+      end
+
+      describe 'get_id' do
+        it "should return nil" do
+          random_id = gen_name('')
+          expect(zbx.hosts.get_id(:hostids => [random_id])).to be_kind_of(NilClass)
+        end
+      end
+    end
+  end
+
+  context 'when interface exists' do
+    before :all do
+      @host = gen_name 'host'
+      @hostid = zbx.hosts.create(
+          :host => @host,
+          :interfaces => [
+              {
+                  :type => 1,
+                  :main => 1,
+                  :ip => "10.20.48.88",
+                  :dns => "",
+                  :port => 10050,
+                  :useip => 1
+              }
+          ],
+          :groups => [:groupid => @hostgroupid]
+      )
+      @interfaceid = zbx.hostinterfaces.create(:hostid => @hostid, :type => 1, :main => 0, :ip => "10.20.48.88", :dns => "", :port => 10050, :useip => 1)
+    end
+
+    describe 'get_full_data' do
+      it "should contains created host" do
+        expect(zbx.hostinterfaces.get_full_data(:hostid => "#{@hostid}")[0]).to include("hostid" => "#{@hostid}")
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Adding option to pass more parameters to the get method. 
Add support to the Hostinterface endpoint
Now the dump_by_id can accept the :params key in the arguments and they will be merged for the query, for example, will allow passing: :params => {:selectInterfaces => "extend"} in the hosts context to get the list of the host interfaces in the result