### PR TITLE
Zabbix2.2

### DIFF
--- a/lib/zabbixapi/basic/basic_func.rb
+++ b/lib/zabbixapi/basic/basic_func.rb
@@ -37,7 +37,7 @@ class ZabbixApi
           result.sort
         when Array
           result = obj.dup
-          result.collect { |item| normalize_hash(item) }
+          result.collect { |item| normalize_obj(item) }
           result.sort
         else
           result = obj

--- a/lib/zabbixapi/basic/basic_func.rb
+++ b/lib/zabbixapi/basic/basic_func.rb
@@ -6,8 +6,8 @@ class ZabbixApi
     end
 
     def hash_equals?(a, b)
-      a_new = normalize_hash(a)
-      b_new = normalize_hash(b)
+      a_new = normalize_obj(a)
+      b_new = normalize_obj(b)
       hash1 = a_new.merge(b_new)
       hash2 = b_new.merge(a_new)
       hash1 == hash2
@@ -19,16 +19,28 @@ class ZabbixApi
       obj
     end
 
-    def normalize_hash(hash)
-      result = hash.dup
-      result.delete(:hostid) #TODO remove to logig. TemplateID and HostID has different id 
-      result.each do |key, value|
-        case value
-          when Array
-            result.delete(key)
-          else
-            result[key] = value.to_s
-        end
+    def normalize_obj(obj)
+      obj.delete(:hostid) #TODO remove to logig. TemplateID and HostID has different id
+      case obj
+        when Hash
+          result = obj.dup
+          result.each do |key, value|
+            case value
+              when Array
+                result[key] = normalize_obj(value)
+              when Hash
+                result[key] = normalize_obj(value)
+              else
+                result[key] = value.to_s
+            end
+          end
+          result.sort
+        when Array
+          result = obj.dup
+          result.collect { |item| normalize_hash(item) }
+          result.sort
+        else
+          result = obj
       end
       result
     end

--- a/lib/zabbixapi/basic/basic_func.rb
+++ b/lib/zabbixapi/basic/basic_func.rb
@@ -1,3 +1,9 @@
+class Hash
+  def <=> (other_hash)
+    self.keys.collect!{|key| key.to_s} <=> other_hash.keys.collect!{|key| key.to_s}
+  end
+end
+
 class ZabbixApi
   class Basic
 
@@ -20,28 +26,21 @@ class ZabbixApi
     end
 
     def normalize_obj(obj)
-      obj.delete(:hostid) #TODO remove to logig. TemplateID and HostID has different id
+      result = nil
+      # obj.delete(:hostid) if obj.is_a? Hash #TODO remove to logig. TemplateID and HostID has different id
       case obj
         when Hash
           result = obj.dup
-          result.each do |key, value|
-            case value
-              when Array
-                result[key] = normalize_obj(value)
-              when Hash
-                result[key] = normalize_obj(value)
-              else
-                result[key] = value.to_s
-            end
+          result.each do |key,value|
+            result[key] = normalize_obj(value)
           end
-          result.sort
         when Array
           result = obj.dup
-          result.collect { |item| normalize_obj(item) }
-          result.sort
+          result.collect! {|item| normalize_obj(item)}
         else
-          result = obj
+          result = obj.to_s
       end
+      result.sort! if result.respond_to?(:sort!)
       result
     end
 

--- a/lib/zabbixapi/basic/basic_logic.rb
+++ b/lib/zabbixapi/basic/basic_logic.rb
@@ -93,7 +93,7 @@ class ZabbixApi
 
       result = symbolize_keys( get_full_data(data) )
       id = nil
-      result.each { |item| id = item[key.to_sym].to_i if item[indentify.to_sym] == data[indentify.to_sym] }
+      result.each { |item| id = item[key.to_sym].to_i if item[indentify.to_sym].to_s == data[indentify.to_sym].to_s }
       id
     end
 

--- a/lib/zabbixapi/classes/hostinterfaces.rb
+++ b/lib/zabbixapi/classes/hostinterfaces.rb
@@ -9,7 +9,7 @@ class ZabbixApi
     end
 
     def indentify
-      "hostid"
+      "interfaceid"
     end
 
     def key

--- a/lib/zabbixapi/classes/hosts.rb
+++ b/lib/zabbixapi/classes/hosts.rb
@@ -35,9 +35,9 @@ class ZabbixApi
       result.empty? ? false : true
     end
 
-    def create_or_update(data)
+    def create_or_update(data, force = false)
       hostid = get_id(:host => data[:host])
-      hostid ? update(data.merge(:hostid => hostid)) : create(data)
+      hostid ? update(data.merge(:hostid => hostid), force) : create(data)
     end
 
     # to make delete call idempotent for all resources

--- a/lib/zabbixapi/classes/triggers.rb
+++ b/lib/zabbixapi/classes/triggers.rb
@@ -49,10 +49,13 @@ class ZabbixApi
 
       log "[DEBUG] expression: #{dump[:expression]}\n data: #{data[:expression]}"
 
+      dump.delete(key.to_sym)
+      data.delete(key.to_sym)
       if hash_equals?(dump, data)
         log "[DEBUG] Equal keys #{dump} and #{data}, skip update"
         item_id
       else
+        data[key.to_sym] = item_id
         data[:expression] = old_expression
         # disable old trigger
         log "[DEBUG] disable :" + @client.api_request(:method => "#{method_name}.update", :params => [{:triggerid=> data[:triggerid], :status => "1" }]).inspect

--- a/lib/zabbixapi/version.rb
+++ b/lib/zabbixapi/version.rb
@@ -1,3 +1,3 @@
 class ZabbixApi
-  VERSION = "2.2.3"
+  VERSION = "2.2.4"
 end

--- a/spec/host.rb
+++ b/spec/host.rb
@@ -5,7 +5,9 @@ require 'spec_helper'
 describe 'host' do
   before :all do
     @hostgroup = gen_name 'hostgroup'
+    @hostgroup3 = gen_name 'hostgroup'
     @hostgroupid = zbx.hostgroups.create(:name => @hostgroup)
+    @hostgroupid3 = zbx.hostgroups.create(:name => @hostgroup3)
   end
 
   context 'when name not exists' do
@@ -119,6 +121,30 @@ describe 'host' do
           ],
           :groups => [:groupid => @hostgroupid]
         ).should eq @hostid
+      end
+
+      it "should add ghostgroup" do
+        zbx.hosts.create_or_update( {
+            :host => @host,
+            :interfaces => [
+                {
+                    :type => 1,
+                    :main => 1,
+                    :ip => "10.20.48.89",
+                    :port => 10050,
+                    :useip => 1,
+                    :dns => ''
+                }
+            ],
+            :groups => [{:groupid => @hostgroupid},
+                        {:groupid => @hostgroupid3}]
+                                    }, true)
+        zbx.hosts.get_full_data(
+            :host => @host,
+            :params => {
+                :selectGroups => "extend"
+            }
+        )[0]["groups"].collect { |group| group["groupid"].to_s }.sort.should eq [@hostgroupid, @hostgroupid3].collect{|item| item.to_s}.sort
       end
     end
 

--- a/spec/hostinterface.rb
+++ b/spec/hostinterface.rb
@@ -62,18 +62,27 @@ describe "hostinterface" do
                   :dns => "",
                   :port => 10050,
                   :useip => 1
-              }
+              },
           ],
           :groups => [:groupid => @hostgroupid]
       )
-      @interfaceid = zbx.hostinterfaces.create(:hostid => @hostid, :type => 1, :main => 0, :ip => "10.20.48.88", :dns => "", :port => 10050, :useip => 1)
+      @interfaceid1 = zbx.hostinterfaces.create(:hostid => @hostid, :type => 1, :main => 0, :ip => "10.20.48.88", :dns => "", :port => 10050, :useip => 1)
+      @interfaceid2 = zbx.hostinterfaces.create(:hostid => @hostid, :type => 1, :main => 0, :ip => "10.20.48.88", :dns => "", :port => 10050, :useip => 1)
     end
 
     describe 'get_full_data' do
       it "should contains created host" do
-        expect(zbx.hostinterfaces.get_full_data(:hostid => "#{@hostid}")[0]).to include("hostid" => "#{@hostid}")
+        expect(zbx.hostinterfaces.get_full_data(:params => {:filter =>  {:hostid => "#{@hostid}"}})[0]).to include("hostid" => "#{@hostid}")
       end
     end
 
+    describe 'get_id' do
+      it "should update existing interface" do
+        zbx.hostinterfaces.create_or_update(:interfaceid => @interfaceid1, :type => 2, :ip => "8.8.8.8")
+        dump = zbx.hostinterfaces.get_full_data(:interfaceid => @interfaceid1)
+        dump[0]["type"].to_s.should eq 2.to_s
+        dump[0]["ip"].to_s.should eq "8.8.8.8"
+      end
+    end
   end
 end


### PR DESCRIPTION
1. The normalize only checks 1 layer. if the object is nested, we need to normalize all layers.
2. The removal of the :hostid should be done in the calling function, the hash_equals should already accept 2 equal or non-equal hashes.
3. When using deep normalization, we need to add <=> method to the Hash
4. Even when using deep normalization, the hash_equals doesn't always find mis-similarities since the calling method mostly sends dump of the data which isn't full (for example, in case of hosts, the hostgroups are missing from the dump) do added a force boolean to force updating and don't check for similarity
