### PR TITLE
test fixes + get_id improvement

### DIFF
--- a/lib/zabbixapi/basic/basic_logic.rb
+++ b/lib/zabbixapi/basic/basic_logic.rb
@@ -2,7 +2,7 @@ class ZabbixApi
   class Basic
 
     def create(data)
-      log "[DEBUG] Call create with parametrs: #{data.inspect}"
+      log "[DEBUG] Call create with parameters: #{data.inspect}"
 
       data_with_default = default_options.empty? ? data : merge_params(default_options, data)
       data_create = [data_with_default]
@@ -11,7 +11,7 @@ class ZabbixApi
     end
 
     def delete(data)
-      log "[DEBUG] Call delete with parametrs: #{data.inspect}"
+      log "[DEBUG] Call delete with parameters: #{data.inspect}"
 
       data_delete = [data]
       result = @client.api_request(:method => "#{method_name}.delete", :params => data_delete)
@@ -19,14 +19,14 @@ class ZabbixApi
     end
 
     def create_or_update(data)
-      log "[DEBUG] Call create_or_update with parametrs: #{data.inspect}"
+      log "[DEBUG] Call create_or_update with parameters: #{data.inspect}"
 
       id = get_id(indentify.to_sym => data[indentify.to_sym])
       id ? update(data.merge(key.to_sym => id.to_s)) : create(data)
     end
 
     def update(data, force=false)
-      log "[DEBUG] Call update with parametrs: #{data.inspect}"
+      log "[DEBUG] Call update with parameters: #{data.inspect}"
 
       dump = {}
       item_id = data[key.to_sym].to_i
@@ -46,7 +46,7 @@ class ZabbixApi
     end
 
     def get_full_data(data)
-      log "[DEBUG] Call get_full_data with parametrs: #{data.inspect}"
+      log "[DEBUG] Call get_full_data with parameters: #{data.inspect}"
 
       @client.api_request(
         :method => "#{method_name}.get",
@@ -69,7 +69,7 @@ class ZabbixApi
     end
 
     def dump_by_id(data)
-      log "[DEBUG] Call dump_by_id with parametrs: #{data.inspect}"
+      log "[DEBUG] Call dump_by_id with parameters: #{data.inspect}"
 
       @client.api_request(
         :method => "#{method_name}.get",
@@ -91,16 +91,29 @@ class ZabbixApi
     end
 
     def get_id(data)
-      log "[DEBUG] Call get_id with parametrs: #{data.inspect}"
+      log "[DEBUG] Call get_id with parameters: #{data.inspect}"
 
-      result = symbolize_keys( get_full_data(data) )
+      # symbolize keys if the user used string keys instead of symbols
+      data = symbolize_keys(data) if data.key?(indentify)
+      # raise an error if indentify name was not supplied 
+      name = data[indentify.to_sym]
+      raise ApiError.new("#{indentify} not supplied in call to get_id") if name == nil
+      result = @client.api_request(
+        :method => "#{method_name}.get",
+        :params => {
+          :filter => {
+            indentify.to_sym => name
+          },
+          :output => [key, indentify]
+        }
+      )
       id = nil
-      result.each { |item| id = item[key.to_sym].to_i if item[indentify.to_sym] == data[indentify.to_sym] }
+      result.each { |item| id = item[key].to_i if item[indentify] == data[indentify.to_sym] }
       id
     end
 
     def get_or_create(data)
-      log "[DEBUG] Call get_or_create with parametrs: #{data.inspect}"
+      log "[DEBUG] Call get_or_create with parameters: #{data.inspect}"
 
       unless (id = get_id(data))
         id = create(data)

--- a/spec/action.rb
+++ b/spec/action.rb
@@ -1,0 +1,79 @@
+#encoding: utf-8
+
+require 'spec_helper'
+
+describe 'action' do
+  before do
+    @actionname = gen_name 'action'
+    @usergroupid = zbx.usergroups.create(:name => gen_name('usergroup'))
+    @actiondata = {
+        :name => @actionname,
+        :eventsource => '0',                    # event source is a triggerid
+        :status => '0',                         # action is enabled
+        :esc_period => '120',                   # how long each step should take
+        :def_shortdata => "Email header",
+        :def_longdata => "Email content",
+        :filter => {
+            :evaltype => '1',                   # perform 'and' between the conditions
+            :conditions => [
+                {
+                    :conditiontype => '3',      # trigger name
+                    :operator => '2',           # like
+                    :value => 'pattern'         # the pattern
+                },
+                {
+                    :conditiontype => '5',      # trigger value
+                    :operator => '0',           # equal
+                    :value => '1'               # 'on'
+                },
+                {
+                    :conditiontype => '4',      # trigger severity
+                    :operator => '5',           # >=
+                    :value => '3'               # average
+                }
+            ]
+        },
+        :operations => [
+            {
+                :operationtype => '0',              # send message
+                :opmessage_grp => [                 # who the message will be sent to
+                    {
+                        :usrgrpid => @usergroupid
+                    }
+                ],
+                :opmessage => {
+                    :default_msg => '0',            # use default message
+                    :mediatypeid =>  '1'            # email id
+                }
+            }
+        ]
+    }
+  end
+
+  context 'when not exists' do
+    describe 'create' do
+      it "should return integer id" do
+        actionid = zbx.actions.create(@actiondata)
+        expect(actionid).to be_kind_of(Integer)
+      end
+    end
+  end
+
+  context 'when exists' do
+    before do
+      @actionid = zbx.actions.create(@actiondata)
+    end
+
+    describe 'create_or_update' do
+      it "should return id" do
+        expect(zbx.actions.create_or_update(@actiondata)).to eq @actionid
+      end
+    end
+
+    describe 'delete' do
+      it "should return id" do
+        expect(zbx.actions.delete(@actionid)).to eq @actionid
+      end
+    end    
+  end
+end

--- a/spec/application.rb
+++ b/spec/application.rb
@@ -24,7 +24,7 @@ describe 'application' do
           :name => @application,
           :hostid => @templateid
         )
-        applicationid.should be_kind_of(Integer)
+        expect(applicationid).to be_kind_of(Integer)
       end
     end
 
@@ -67,7 +67,7 @@ describe 'application' do
 
     describe "delete" do
       it "should return id" do
-        zbx.applications.delete(@applicationid).should eq @applicationid
+        expect(zbx.applications.delete(@applicationid)).to eq @applicationid
       end
     end
   end

--- a/spec/graph.rb
+++ b/spec/graph.rb
@@ -66,13 +66,13 @@ describe 'graph' do
 
     describe 'get_or_create' do
       it "should return id of existing graph" do
-        zbx.graphs.get_or_create(
+        expect(zbx.graphs.get_or_create(
           :gitems => [gitems],
           :show_triggers => "0",
           :name => @graph,
           :width => "900",
           :height => "200"
-        ).should eq @graphid
+        )).to eq @graphid
       end
     end
 
@@ -92,37 +92,37 @@ describe 'graph' do
 
     describe 'get_id' do
       it "should return id" do
-        zbx.graphs.get_id( :name => @graph ).should eq @graphid
+        expect(zbx.graphs.get_id( :name => @graph )).to eq @graphid
       end
     end
 
     describe 'get_ids_by_host' do
       it "should contains id of graph" do
         graph_array = zbx.graphs.get_ids_by_host( :host => @host )
-        graph_array.should be_kind_of(Array)
-        graph_array.should include(@graphid.to_s)
+        expect(graph_array).to be_kind_of(Array)
+        expect(graph_array).to include(@graphid.to_s)
       end
     end
 
     describe 'update' do
       it "should return id" do
-        zbx.graphs.update(
+        expect(zbx.graphs.update(
           :graphid => @graphid,
           :gitems => [gitems],
           :ymax_type => 1
-        ).should eq @graphid
+        )).to eq @graphid
       end
     end
 
     describe 'create_or_update' do
       it "should return existing id" do
-        zbx.graphs.create_or_update(
+        expect(zbx.graphs.create_or_update(
           :gitems => [gitems],
           :show_triggers => "1",
           :name => @graph,
           :width => "900",
           :height => "200"
-        ).should eq @graphid
+        )).to eq @graphid
       end
     end
 

--- a/spec/host.rb
+++ b/spec/host.rb
@@ -29,7 +29,7 @@ describe 'host' do
           ],
           :groups => [:groupid => @hostgroupid]
         )
-        hostid.should be_kind_of(Integer)
+        expect(hostid).to be_kind_of(Integer)
       end
 
       it "should create host in multiple groups" do
@@ -54,6 +54,7 @@ describe 'host' do
     describe 'get_id' do
       it "should return nil" do
         expect(zbx.hosts.get_id(:host => @host)).to be_kind_of(NilClass)
+        expect(zbx.hosts.get_id('host' => @host)).to be_kind_of(NilClass)
       end
     end
   end
@@ -95,12 +96,13 @@ describe 'host' do
     describe 'get_id' do
       it "should return id of host" do
         expect(zbx.hosts.get_id(:host => @host)).to eq @hostid
+        expect(zbx.hosts.get_id('host' => @host)).to eq @hostid
       end
     end
 
     describe 'create_or_update' do
       it "should return id of updated host" do
-        zbx.hosts.create_or_update(
+        expect(zbx.hosts.create_or_update(
           :host => @host,
           :interfaces => [
             {
@@ -113,25 +115,25 @@ describe 'host' do
             }
           ],
           :groups => [:groupid => @hostgroupid]
-        ).should eq @hostid
+        )).to eq @hostid
       end
     end
 
     describe 'update' do
       it "should return id" do
-        zbx.hosts.update(
+        expect(zbx.hosts.update(
           :hostid => @hostid,
           :status => 0
-        ).should eq @hostid
+        )).to eq @hostid
       end
 
       it "should update groups" do
         @hostgroupid2 = zbx.hostgroups.create(:name => gen_name('hostgroup'))
 
-        zbx.hosts.update(
+        expect(zbx.hosts.update(
             :hostid  =>  @hostid,
             :groups => [ :groupid => @hostgroupid2]
-        ).should eq @hostid
+        )).to eq @hostid
 
         expect(zbx.hosts.dump_by_id(:hostid => @hostid).first['groups'].first["groupid"]).to eq @hostgroupid2.to_s
 
@@ -167,9 +169,8 @@ describe 'host' do
 
     describe 'delete' do
       it "HOST: Delete" do
-        zbx.hosts.delete( @hostid ).should eq @hostid
+        expect(zbx.hosts.delete( @hostid )).to eq @hostid
       end
     end
   end
 end
-

--- a/spec/hostgroup.rb
+++ b/spec/hostgroup.rb
@@ -20,35 +20,35 @@ describe 'hostgroup' do
 
     describe 'get_id' do
       it "should return id" do
-        zbx.hostgroups.get_id(:name => @hostgroup).should eq @hostgroupid
+        expect(zbx.hostgroups.get_id(:name => @hostgroup)).to eq @hostgroupid
       end
 
       it "should return nil for not existing group" do
-        zbx.hostgroups.get_id(:name => "#{@hostgroup}______").should be_kind_of(NilClass)
+        expect(zbx.hostgroups.get_id(:name => "#{@hostgroup}______")).to be_kind_of(NilClass)
       end
     end
 
     describe 'get_or_create' do
       it "should return id of existing hostgroup" do
-        zbx.hostgroups.get_or_create(:name => @hostgroup).should eq @hostgroupid
+        expect(zbx.hostgroups.get_or_create(:name => @hostgroup)).to eq @hostgroupid
       end
     end
 
     describe 'create_or_update' do
       it "should return id of hostgroup" do
-        zbx.hostgroups.create_or_update(:name => @hostgroup).should eq @hostgroupid
+        expect(zbx.hostgroups.create_or_update(:name => @hostgroup)).to eq @hostgroupid
       end
     end
 
     describe 'all' do
       it "should contains created hostgroup" do
-        zbx.hostgroups.all.should include(@hostgroup => @hostgroupid.to_s)
+        expect(zbx.hostgroups.all).to include(@hostgroup => @hostgroupid.to_s)
       end
     end
 
     describe "delete" do
       it "shold return id" do
-        zbx.hostgroups.delete(@hostgroupid).should eq @hostgroupid
+        expect(zbx.hostgroups.delete(@hostgroupid)).to eq @hostgroupid
       end
     end
   end

--- a/spec/item.rb
+++ b/spec/item.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe 'application' do
+describe 'item' do
   before :all do
     @hostgroup = gen_name 'hostgroup'
     @hostgroupid = zbx.hostgroups.create(:name => @hostgroup)
@@ -32,13 +32,13 @@ describe 'application' do
           :hostid => @templateid,
           :applications => [@applicationid]
         )
-        itemid.should be_kind_of(Integer)
+        expect(itemid).to be_kind_of(Integer)
       end
     end
 
     describe 'get_id' do
       it "should return nil" do
-        expect(zbx.items.get_id(:host => @item)).to be_kind_of(NilClass)
+        expect(zbx.items.get_id(:name => @item)).to be_kind_of(NilClass)
       end
     end
   end
@@ -79,24 +79,28 @@ describe 'application' do
       end
     end
 
+    it "should raise error on no identity given" do
+        expect { zbx.items.get_id({}) }.to raise_error(ZabbixApi::ApiError)
+    end
+
     describe 'update' do
       it "should return id" do
-        zbx.items.update(
+        expect(zbx.items.update(
           :itemid => zbx.items.get_id(:name => @item),
           :status => 1
-        ).should eq @itemid
+        )).to eq @itemid
       end
     end
 
     describe 'create_or_update' do
       it "should update existing item" do
-        zbx.items.create_or_update(
+        expect(zbx.items.create_or_update(
           :name => @item,
           :key_ => "proc.num[#{gen_name 'proc'}]",
           :status => 0,
           :hostid => @templateid,
           :applications => [@applicationid]
-        ).should eq @itemid
+        )).to eq @itemid
       end
 
       it "should create item" do
@@ -123,10 +127,8 @@ describe 'application' do
       end
 
       it "should delete item from zabbix" do
-        expect(zbx.items.get_id(:id => @itemid)).to be_nil
+        expect(zbx.items.get_id(:name => @item)).to be_nil
       end
     end
   end
 end
-
-

--- a/spec/maintenance.rb
+++ b/spec/maintenance.rb
@@ -41,35 +41,35 @@ describe 'maintenance' do
 
     describe 'get_id' do
       it "should return id" do
-        zbx.maintenance.get_id(:name => @maintenance).should eq @maintenanceid
+        expect(zbx.maintenance.get_id(:name => @maintenance)).to eq @maintenanceid
       end
 
       it "should return nil for not existing group" do
-        zbx.maintenance.get_id(:name => "#{@maintenance}______").should be_kind_of(NilClass)
+        expect(zbx.maintenance.get_id(:name => "#{@maintenance}______")).to be_kind_of(NilClass)
       end
     end
 
     describe 'get_or_create' do
       it "should return id of existing maintenance" do
-        zbx.maintenance.get_or_create(:name => @maintenance).should eq @maintenanceid
+        expect(zbx.maintenance.get_or_create(:name => @maintenance)).to eq @maintenanceid
       end
     end
 
     describe 'create_or_update' do
       it "should return id of maintenance" do
-        zbx.maintenance.create_or_update(:name => @maintenance).should eq @maintenanceid
+        expect(zbx.maintenance.create_or_update(:name => @maintenance)).to eq @maintenanceid
       end
     end
 
     describe 'all' do
       it "should contains created maintenance" do
-        zbx.maintenance.all.should include(@maintenance => @maintenanceid.to_s)
+        expect(zbx.maintenance.all).to include(@maintenance => @maintenanceid.to_s)
       end
     end
 
     describe "delete" do
       it "shold return id" do
-        zbx.maintenance.delete(@maintenanceid).should eq @maintenanceid
+        expect(zbx.maintenance.delete(@maintenanceid)).to eq @maintenanceid
       end
     end
 	

--- a/spec/mediatype.rb
+++ b/spec/mediatype.rb
@@ -17,7 +17,7 @@ describe 'mediatype' do
         :smtp_email => "zabbix@test.com",
         :smtp_helo => "test.com"
       )
-      mediatypeid.should be_kind_of(Integer)
+      expect(mediatypeid).to be_kind_of(Integer)
     end
     end
   end
@@ -35,11 +35,11 @@ describe 'mediatype' do
 
     describe 'create_or_update' do
       it "should return id" do
-        zbx.mediatypes.create_or_update(
+        expect(zbx.mediatypes.create_or_update(
           :description => @mediatype,
           :smtp_email => "zabbix2@test.com",
           :smtp_helo => "test.com"
-        ).should eq @mediatypeid
+        )).to eq @mediatypeid
       end
 
       it "should return id" do

--- a/spec/query.rb
+++ b/spec/query.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe "query" do
   it "should works" do
-    zbx.query(
+    expect(zbx.query(
       method: 'host.get',
       params: {
         filter: {
@@ -12,7 +12,7 @@ describe "query" do
         },
         selectInterfaces: 'refer'
       }
-    ).should be_kind_of(Array)
+    )).to be_kind_of(Array)
   end
 end
 

--- a/spec/screen.rb
+++ b/spec/screen.rb
@@ -55,7 +55,7 @@ describe 'screen' do
           :screen_name => @screen_name,
           :graphids => [@graphid]
         )
-        screenid.should be_kind_of(Integer)
+        expect(screenid).to be_kind_of(Integer)
       end
     end
   end
@@ -75,13 +75,13 @@ describe 'screen' do
           :screen_name => @screen_name,
           :graphids => [@graphid]
         )
-        screenid.should eq @screenid
+        expect(screenid).to eq @screenid
       end
     end
 
     describe 'delete' do
       it "should return id" do
-        zbx.screens.delete(@screenid).should eq @screenid
+        expect(zbx.screens.delete(@screenid)).to eq @screenid
       end
     end
   end

--- a/spec/server.rb
+++ b/spec/server.rb
@@ -5,13 +5,11 @@ require 'spec_helper'
 describe 'server' do
   describe 'version' do
     it "should be string" do
-      zbx.server.version.should be_kind_of(String)
+      expect(zbx.server.version).to be_kind_of(String)
     end
 
     it "should be 2.4.x or 3.0.x or 3.2.x" do
-      zbx.server.version.should match(/(2\.4|3\.[02])\.\d+/)
+      expect(zbx.server.version).to match(/(2\.4|3\.[02])\.\d+/)
     end
   end
 end
-
-

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,8 +4,8 @@ require 'zabbixapi'
 def zbx
   # settings
   @api_url = ENV['ZABBIX_HOST_URL'] || 'http://10.211.55.6/api_jsonrpc.php'
-  @api_login = 'Admin'
-  @api_password = 'zabbix'
+  @api_login = ENV['ZABBIX_USERNAME'] || 'Admin'
+  @api_password = ENV['ZABBIX_PASSWORD'] || 'zabbix'
 
   @zbx ||= ZabbixApi.connect(
     :url => @api_url,

--- a/spec/template.rb
+++ b/spec/template.rb
@@ -19,7 +19,7 @@ describe "template" do
           :host => @template,
           :groups => [:groupid => @hostgroupid]
         )
-        templateid.should be_kind_of(Integer)
+        expect(templateid).to be_kind_of(Integer)
       end
     end
 
@@ -62,7 +62,7 @@ describe "template" do
 
     describe "all" do
       it "should contains template" do
-        zbx.templates.all.should include(@template => @templateid.to_s)
+        expect(zbx.templates.all).to include(@template => @templateid.to_s)
       end
     end
 
@@ -73,7 +73,7 @@ describe "template" do
           :host => template,
           :groups => [:groupid => @hostgroupid]
         )
-        zbx.templates.delete(templateid).should eq templateid
+        expect(zbx.templates.delete(templateid)).to eq templateid
       end
     end
 
@@ -99,10 +99,10 @@ describe "template" do
       context "not linked with host" do
         describe "mass_update" do
           it "should return true" do
-            zbx.templates.mass_update(
+            expect(zbx.templates.mass_update(
               :hosts_id => [@hostid],
               :templates_id => [@templateid]
-            ).should be_true
+            )).to be true
           end
         end
       end
@@ -120,26 +120,26 @@ describe "template" do
             tmpl_array = zbx.templates.get_ids_by_host(
               :hostids => [@hostid]
             )
-            tmpl_array.should be_kind_of(Array)
-            tmpl_array.should include @templateid.to_s
+            expect(tmpl_array).to be_kind_of(Array)
+            expect(tmpl_array).to include @templateid.to_s
           end
         end
 
         describe "mass_add" do
           it "should return true" do
-            zbx.templates.mass_add(
+            expect(zbx.templates.mass_add(
               :hosts_id => [@hostid],
               :templates_id => [@templateid]
-            ).should be_kind_of(TrueClass)
+            )).to be_kind_of(TrueClass)
           end
         end
 
         describe "mass_remove" do
           it "should return true" do
-            zbx.templates.mass_remove(
+            expect(zbx.templates.mass_remove(
               :hosts_id => [@hostid],
               :templates_id => [@templateid]
-            ).should be_true
+            )).to be true
           end
         end
       end

--- a/spec/trigger.rb
+++ b/spec/trigger.rb
@@ -41,7 +41,7 @@ describe "trigger" do
           :status     => 0,
           :type => 0
         )
-        triggerid.should be_kind_of(Integer)
+        expect(triggerid).to be_kind_of(Integer)
       end
     end
   end
@@ -61,13 +61,13 @@ describe "trigger" do
 
     describe "get_id" do
       it "should return id" do
-        zbx.triggers.get_id(:description => @trigger).should eq @triggerid
+        expect(zbx.triggers.get_id(:description => @trigger)).to eq @triggerid
       end
     end
 
     describe "delete" do
       it "should return id" do
-        zbx.triggers.delete( @triggerid ).should eq @triggerid
+        expect(zbx.triggers.delete( @triggerid )).to eq @triggerid
       end
     end
   end

--- a/spec/user.rb
+++ b/spec/user.rb
@@ -38,13 +38,13 @@ describe 'user' do
           :passwd => user,
           :usrgrps => [@usergroupid]
         )
-        userid.should be_kind_of(Integer)
+        expect(userid).to be_kind_of(Integer)
       end
     end
 
     describe 'get_id' do
       it "should return nil" do
-        zbx.users.get_id(:alias => "name_____").should be_nil
+        expect(zbx.users.get_id(:alias => "name_____")).to be_nil
       end
     end
   end
@@ -63,33 +63,33 @@ describe 'user' do
 
     describe 'create_or_update' do
       it "should return id" do
-        zbx.users.create_or_update(
+        expect(zbx.users.create_or_update(
           :alias => @user,
           :name => @user,
           :surname => @user,
           :passwd => @user
-        ).should eq @userid
+        )).to eq @userid
       end
     end
 
     describe 'get_full_data' do
       it "should return string name" do
-        zbx.users.get_full_data(:alias => @user)[0]['name'].should be_kind_of(String)
+        expect(zbx.users.get_full_data(:alias => @user)[0]['name']).to be_kind_of(String)
       end
     end
 
     describe 'update' do
       it "should return id" do
-        zbx.users.update(:userid => @userid, :name => gen_name('user')).should eq @userid
+        expect(zbx.users.update(:userid => @userid, :name => gen_name('user'))).to eq @userid
       end
     end
 
     describe 'add_medias' do
       it "should return integer media id" do
-        zbx.users.add_medias(
+        expect(zbx.users.add_medias(
           :userids => [@userid],
           :media => [media]
-        ).should be_kind_of(Integer)
+        )).to be_kind_of(Integer)
       end
     end
 
@@ -102,14 +102,14 @@ describe 'user' do
             :media => [media]
           )
 
-          returned_userid.should eq @userid
+          expect(returned_userid).to eq @userid
         end
       end
     end
 
     describe 'delete' do
       it "should return id" do
-        zbx.users.delete(@userid).should eq @userid
+        expect(zbx.users.delete(@userid)).to eq @userid
       end
     end
   end

--- a/spec/usergroup.rb
+++ b/spec/usergroup.rb
@@ -7,7 +7,7 @@ describe 'usergroup' do
   context 'when not exists' do
     it "should be integer id" do
       usergroupid = zbx.usergroups.create(:name => gen_name('usergroup'))
-      usergroupid.should be_kind_of(Integer)
+      expect(usergroupid).to be_kind_of(Integer)
     end
   end
 
@@ -37,41 +37,41 @@ describe 'usergroup' do
 
     describe 'get_or_create' do
       it "should return id" do
-        zbx.usergroups.get_or_create(:name => @usergroup).should eq @usergroupid
+        expect(zbx.usergroups.get_or_create(:name => @usergroup)).to eq @usergroupid
       end
     end
 
     describe 'add_user' do
       it "should return id" do
-        zbx.usergroups.add_user(
+        expect(zbx.usergroups.add_user(
             :usrgrpids => [@usergroupid],
             :userids => [@userid2]
-        ).should eq @usergroupid
+        )).to eq @usergroupid
       end
     end
 
     describe 'update_users' do
       it "should return id" do
-        zbx.usergroups.update_users(
+        expect(zbx.usergroups.update_users(
             :usrgrpids => [@usergroupid],
             :userids => [@userid2]
-        ).should eq @usergroupid
+        )).to eq @usergroupid
       end
     end
 
     describe 'set_perms' do
       it "should return id" do
-        zbx.usergroups.set_perms(
+        expect(zbx.usergroups.set_perms(
           :usrgrpid => @usergroupid,
           :hostgroupids => zbx.hostgroups.all.values,
           :permission => 3
-        ).should eq @usergroupid
+        )).to eq @usergroupid
       end
     end
 
     describe 'delete' do
       it "should raise error when has users with only one group" do
-        expect { zbx.usergroups.delete(@usergroupid) }.to raise_error
+        expect { zbx.usergroups.delete(@usergroupid) }.to raise_error(ZabbixApi::ApiError)
       end
 
       it "should return id of deleted group" do


### PR DESCRIPTION
get_id will go to zabbix directly + ask only for the key + name back
added tests for actions
added test for string keys to get_id
change all test that use should to use expect. should is deprecated
change a test that uses raise_error to check for a the specific error