### PR TITLE
Usermacros update not working

### DIFF
--- a/lib/zabbixapi/classes/usermacros.rb
+++ b/lib/zabbixapi/classes/usermacros.rb
@@ -8,6 +8,46 @@ class ZabbixApi
       "usermacro"
     end
 
+    def get_id(data)
+      log "[DEBUG] Call get_id with parameters: #{data.inspect}"
+
+      # symbolize keys if the user used string keys instead of symbols
+      data = symbolize_keys(data) if data.key?(indentify)
+      # raise an error if indentify name was not supplied 
+      name = data[indentify.to_sym]
+      raise ApiError.new("#{indentify} not supplied in call to get_id") if name == nil
+
+      result = request(data, "usermacro.get", "hostmacroid")
+
+      result.length > 0 && result[0].key?("hostmacroid") ? result[0]["hostmacroid"].to_i : nil
+    end
+
+    def get_id_global(data)
+      log "[DEBUG] Call get_id_global with parameters: #{data.inspect}"
+
+      # symbolize keys if the user used string keys instead of symbols
+      data = symbolize_keys(data) if data.key?(indentify)
+      # raise an error if indentify name was not supplied 
+      name = data[indentify.to_sym]
+      raise ApiError.new("#{indentify} not supplied in call to get_id") if name == nil
+
+      result = request(data, "usermacro.get", "globalmacroid")
+
+      result.length > 0 && result[0].key?("globalmacroid") ? result[0]["globalmacroid"].to_i : nil
+    end
+
+    def get_full_data(data)
+      log "[DEBUG] Call get_full_data with parameters: #{data.inspect}"
+
+      request(data, "usermacro.get", "hostmacroid")
+    end
+
+    def get_full_data_global(data)
+      log "[DEBUG] Call get_full_data_global with parameters: #{data.inspect}"
+
+      request(data, "usermacro.get", "globalmacroid")
+    end
+
     def create(data)
       request(data, "usermacro.create", "hostmacroids")
     end
@@ -17,11 +57,13 @@ class ZabbixApi
     end
 
     def delete(data)
-      request(data, "usermacro.delete", "hostmacroids")
+      data_delete = [data]
+      request(data_delete, "usermacro.delete", "hostmacroids")
     end
 
     def delete_global(data)
-      request(data, "usermacro.deleteglobal", "globalmacroids")
+      data_delete = [data]
+      request(data_delete, "usermacro.deleteglobal", "globalmacroids")
     end
 
     def update(data)
@@ -35,28 +77,44 @@ class ZabbixApi
     def get_or_create(data)
       log "[DEBUG] Call get_or_create with parameters: #{data.inspect}"
 
-      unless (id = request({:macro => data[:macro], :hostid => data[:hostid]}, "usermacro.get", "hostmacroid"))
+      unless (id = get_id(:macro => data[:macro], :hostid => data[:hostid]))
         id = create(data)
       end
       id
     end
 
+    def get_or_create_global(data)
+      log "[DEBUG] Call get_or_create_global with parameters: #{data.inspect}"
+
+      unless (id = get_id_global(:macro => data[:macro], :hostid => data[:hostid]))
+        id = create_global(data)
+      end
+      id
+    end
+
     def create_or_update(data)
-      hostmacroid = request({:macro => data[:macro], :hostid => data[:hostid]}, "usermacro.get", "hostmacroid")
+      hostmacroid = get_id(:macro => data[:macro], :hostid => data[:hostid])
       hostmacroid ? update(data.merge(:hostmacroid => hostmacroid)) : create(data)
+    end
+
+    def create_or_update_global(data)
+      hostmacroid = get_id_global(:macro => data[:macro], :hostid => data[:hostid])
+      hostmacroid ? update_global(data.merge(:globalmacroid => globalmacroid)) : create_global(data)
     end
 
     private
       def request(data, method, result_key)
-        result = @client.api_request(:method => method, :params => data)
-
-        # Zabbix has different result formats for gets vs updates on macros - boo!
-        if result.kind_of?(Hash) && result.key?(result_key)
-          result[result_key][0].to_i
-        elsif result.kind_of?(Array) && result.length > 0
-          result[0][result_key].to_i
+        # Zabbix has different result formats for gets vs updates
+        if method.include?(".get")
+          if result_key.include?("global")
+            result = @client.api_request(:method => method, :params => { :globalmacro => true, :filter => data })
+          else
+            result = @client.api_request(:method => method, :params => { :filter => data })
+          end
         else
-          nil
+          result = @client.api_request(:method => method, :params => data)
+
+          result.key?(result_key) && result[result_key].length > 0 ? result[result_key][0].to_i : nil
         end
       end
 

--- a/lib/zabbixapi/classes/usermacros.rb
+++ b/lib/zabbixapi/classes/usermacros.rb
@@ -51,9 +51,9 @@ class ZabbixApi
         result = @client.api_request(:method => method, :params => data)
 
         # Zabbix has different result formats for gets vs updates on macros - boo!
-        if result.key?(result_key)
+        if result.kind_of?(Hash) && result.key?(result_key)
           result[result_key][0].to_i
-        elsif result.length > 0
+        elsif result.kind_of?(Array) && result.length > 0
           result[0][result_key].to_i
         else
           nil

--- a/lib/zabbixapi/classes/usermacros.rb
+++ b/lib/zabbixapi/classes/usermacros.rb
@@ -49,7 +49,15 @@ class ZabbixApi
     private
       def request(data, method, result_key)
         result = @client.api_request(:method => method, :params => data)
-        result.empty? ? nil : result[result_key][0].to_i
+
+        # Zabbix has different result formats for gets vs updates on macros - boo!
+        if result.key?(result_key)
+          result[result_key][0].to_i
+        elsif result.length > 0
+          result[0][result_key].to_i
+        else
+          nil
+        end
       end
 
   end

--- a/lib/zabbixapi/classes/usermacros.rb
+++ b/lib/zabbixapi/classes/usermacros.rb
@@ -24,12 +24,26 @@ class ZabbixApi
       request(data, "usermacro.deleteglobal", "globalmacroids")
     end
 
-    def update
+    def update(data)
       request(data, "usermacro.update", "hostmacroids")
     end
 
-    def update_global
+    def update_global(data)
       request(data, "usermacro.updateglobal", "globalmacroids")
+    end
+
+    def get_or_create(data)
+      log "[DEBUG] Call get_or_create with parameters: #{data.inspect}"
+
+      unless (id = request({:macro => data[:macro], :hostid => data[:hostid]}, "usermacro.get", "hostmacroid"))
+        id = create(data)
+      end
+      id
+    end
+
+    def create_or_update(data)
+      hostmacroid = request({:macro => data[:macro], :hostid => data[:hostid]}, "usermacro.get", "hostmacroid")
+      hostmacroid ? update(data.merge(:hostmacroid => hostmacroid)) : create(data)
     end
 
     private

--- a/spec/usermacro.rb
+++ b/spec/usermacro.rb
@@ -1,0 +1,192 @@
+#encoding: utf-8
+
+require 'spec_helper'
+
+describe 'usermacro' do
+  before :all do
+    @hostgroup = gen_name 'hostgroup'
+    @hostgroupid = zbx.hostgroups.create(:name => @hostgroup)
+    @template = gen_name 'template'
+    @templateid = zbx.templates.create(
+      :host => @template,
+      :groups => [:groupid => @hostgroupid]
+    )
+  end
+
+  context 'when hostmacro not exists' do
+    before do
+      @hostmacro = gen_name 'hostmacro'
+    end
+
+    describe 'create' do
+      it "should return integer id" do
+        hostmacroid = zbx.usermacros.create(
+          :macro => @hostmacro,
+          :value => "public",
+          :hostid => @templateid
+        )
+        expect(hostmacroid).to be_kind_of(Integer)
+      end
+    end
+
+    describe 'get_id' do
+      it "should return nil" do
+        expect(zbx.usermacros.get_id(:macro => @hostmacro)).to be_kind_of(NilClass)
+      end
+    end
+  end
+
+  context 'when hostmacro exists' do
+    before :all do
+      @hostmacro = gen_name 'hostmacro'
+      @hostmacroid = zbx.usermacros.create(
+        :macro => @hostmacro,
+        :value => "public",
+        :hostid => @templateid
+      )
+    end
+
+    describe 'get_or_create' do
+      it "should return id of hostmacro" do
+        expect(zbx.usermacros.get_or_create(
+          :macro => @hostmacro,
+          :value => "public",
+          :hostid => @templateid
+        )).to eq @hostmacroid
+      end
+    end
+
+    describe 'get_full_data' do
+      it "should contains created hostmacro" do
+        expect(zbx.usermacros.get_full_data(:macro => @hostmacro)[0]).to include("macro" => @hostmacro)
+      end
+    end
+
+    describe 'get_id' do
+      it "should return id of hostmacro" do
+        expect(zbx.usermacros.get_id(:macro => @hostmacro)).to eq @hostmacroid
+      end
+    end
+
+    it "should raise error on no identity given" do
+        expect { zbx.usermacros.get_id({}) }.to raise_error(ZabbixApi::ApiError)
+    end
+
+    describe 'update' do
+      it "should return id" do
+        expect(zbx.usermacros.update(
+          :hostmacroid => zbx.usermacros.get_id(:macro => @hostmacro),
+          :value => "private",
+        )).to eq @hostmacroid
+      end
+    end
+
+    describe 'create_or_update' do
+      it "should update existing usermacro" do
+        expect(zbx.usermacros.create_or_update(
+          :macro => @hostmacro,
+          :value => "public",
+          :hostid => @templateid
+        )).to eq @hostmacroid
+      end
+
+      it "should create usermacro" do
+        new_hostmacro_id = zbx.usermacros.create_or_update(
+          :macro => @hostmacro + "____1",
+          :value => "public",
+          :hostid => @templateid
+        )
+
+        expect(new_hostmacro_id).to be_kind_of(Integer)
+        expect(new_hostmacro_id).to be > @hostmacroid
+      end
+    end
+
+    describe 'delete' do
+      before :all do
+        @result = zbx.usermacros.delete(@hostmacroid)
+      end
+
+      it "should return deleted id" do
+        expect(@result).to eq @hostmacroid
+      end
+
+      it "should delete item from zabbix" do
+        expect(zbx.usermacros.get_id(:macro => @hostmacro)).to be_nil
+      end
+    end
+  end
+  
+  context 'when globalmacro not exists' do
+    before do
+      @globalmacro = gen_name 'globalmacro'
+    end
+
+    describe 'create_global' do
+      it "should return integer id" do
+        globalmacroid = zbx.usermacros.create_global(
+          :macro => @globalmacro,
+          :value => "public",
+          :hostid => @templateid
+        )
+        expect(globalmacroid).to be_kind_of(Integer)
+      end
+    end
+
+    describe 'get_id' do
+      it "should return nil" do
+        expect(zbx.usermacros.get_id(:macro => @globalmacro)).to be_kind_of(NilClass)
+      end
+    end
+  end
+
+  context 'when globalmacro exists' do
+    before :all do
+      @globalmacro = gen_name 'globalmacro'
+      @globalmacroid = zbx.usermacros.create_global(
+        :macro => @globalmacro,
+        :value => "public",
+        :hostid => @templateid
+      )
+    end
+
+    describe 'get_full_data' do
+      it "should contains created globalmacro" do
+        expect(zbx.usermacros.get_full_data(:macro => @globalmacro)[0]).to include("macro" => @globalmacro)
+      end
+    end
+
+    describe 'get_id' do
+      it "should return id of globalmacro" do
+        expect(zbx.usermacros.get_id(:macro => @globalmacro)).to eq @globalmacroid
+      end
+    end
+
+    it "should raise error on no identity given" do
+        expect { zbx.usermacros.get_id({}) }.to raise_error(ZabbixApi::ApiError)
+    end
+
+    describe 'update_global' do
+      it "should return id" do
+        expect(zbx.usermacros.update_global(
+          :globalmacroid => zbx.usermacros.get_id(:macro => @globalmacro),
+          :value => "private",
+        )).to eq @globalmacroid
+      end
+    end
+
+    describe 'delete' do
+      before :all do
+        @result = zbx.usermacros.delete(@globalmacroid)
+      end
+
+      it "should return deleted id" do
+        expect(@result).to eq @globalmacroid
+      end
+
+      it "should delete item from zabbix" do
+        expect(zbx.usermacros.get_id(:macro => @globalmacro)).to be_nil
+      end
+    end
+  end
+end

--- a/spec/usermacro.rb
+++ b/spec/usermacro.rb
@@ -126,16 +126,15 @@ describe 'usermacro' do
       it "should return integer id" do
         globalmacroid = zbx.usermacros.create_global(
           :macro => @globalmacro,
-          :value => "public",
-          :hostid => @templateid
+          :value => "public"
         )
         expect(globalmacroid).to be_kind_of(Integer)
       end
     end
 
-    describe 'get_id' do
+    describe 'get_id_global' do
       it "should return nil" do
-        expect(zbx.usermacros.get_id(:macro => @globalmacro)).to be_kind_of(NilClass)
+        expect(zbx.usermacros.get_id_global(:macro => @globalmacro)).to be_kind_of(NilClass)
       end
     end
   end
@@ -145,39 +144,38 @@ describe 'usermacro' do
       @globalmacro = '{$' + gen_name('GLOBALMACRO') + '}'
       @globalmacroid = zbx.usermacros.create_global(
         :macro => @globalmacro,
-        :value => "public",
-        :hostid => @templateid
+        :value => "public"
       )
     end
 
-    describe 'get_full_data' do
+    describe 'get_full_data_global' do
       it "should contains created globalmacro" do
-        expect(zbx.usermacros.get_full_data(:macro => @globalmacro)[0]).to include("macro" => @globalmacro)
+        expect(zbx.usermacros.get_full_data_global(:macro => @globalmacro)[0]).to include("macro" => @globalmacro)
       end
     end
 
-    describe 'get_id' do
+    describe 'get_id_global' do
       it "should return id of globalmacro" do
-        expect(zbx.usermacros.get_id(:macro => @globalmacro)).to eq @globalmacroid
+        expect(zbx.usermacros.get_id_global(:macro => @globalmacro)).to eq @globalmacroid
       end
     end
 
     it "should raise error on no identity given" do
-        expect { zbx.usermacros.get_id({}) }.to raise_error(ZabbixApi::ApiError)
+        expect { zbx.usermacros.get_id_global({}) }.to raise_error(ZabbixApi::ApiError)
     end
 
     describe 'update_global' do
       it "should return id" do
         expect(zbx.usermacros.update_global(
-          :globalmacroid => zbx.usermacros.get_id(:macro => @globalmacro),
+          :globalmacroid => zbx.usermacros.get_id_global(:macro => @globalmacro),
           :value => "private",
         )).to eq @globalmacroid
       end
     end
 
-    describe 'delete' do
+    describe 'delete_global' do
       before :all do
-        @result = zbx.usermacros.delete(@globalmacroid)
+        @result = zbx.usermacros.delete_global(@globalmacroid)
       end
 
       it "should return deleted id" do
@@ -185,7 +183,7 @@ describe 'usermacro' do
       end
 
       it "should delete item from zabbix" do
-        expect(zbx.usermacros.get_id(:macro => @globalmacro)).to be_nil
+        expect(zbx.usermacros.get_id_global(:macro => @globalmacro)).to be_nil
       end
     end
   end

--- a/spec/usermacro.rb
+++ b/spec/usermacro.rb
@@ -15,7 +15,7 @@ describe 'usermacro' do
 
   context 'when hostmacro not exists' do
     before do
-      @hostmacro = '{$' + gen_name('hostmacro') + '}'
+      @hostmacro = '{$' + gen_name('HOSTMACRO') + '}'
     end
 
     describe 'create' do
@@ -38,7 +38,7 @@ describe 'usermacro' do
 
   context 'when hostmacro exists' do
     before :all do
-      @hostmacro = '{$' + gen_name('hostmacro') + '}'
+      @hostmacro = '{$' + gen_name('HOSTMACRO') + '}'
       @hostmacroid = zbx.usermacros.create(
         :macro => @hostmacro,
         :value => "public",
@@ -119,7 +119,7 @@ describe 'usermacro' do
   
   context 'when globalmacro not exists' do
     before do
-      @globalmacro = '{$' + gen_name('globalmacro') + '}'
+      @globalmacro = '{$' + gen_name('GLOBALMACRO') + '}'
     end
 
     describe 'create_global' do
@@ -142,7 +142,7 @@ describe 'usermacro' do
 
   context 'when globalmacro exists' do
     before :all do
-      @globalmacro = '{$' + gen_name('globalmacro') + '}'
+      @globalmacro = '{$' + gen_name('GLOBALMACRO') + '}'
       @globalmacroid = zbx.usermacros.create_global(
         :macro => @globalmacro,
         :value => "public",

--- a/spec/usermacro.rb
+++ b/spec/usermacro.rb
@@ -15,7 +15,7 @@ describe 'usermacro' do
 
   context 'when hostmacro not exists' do
     before do
-      @hostmacro = '{$' + gen_name 'hostmacro' + '}'
+      @hostmacro = '{$' + gen_name('hostmacro') + '}'
     end
 
     describe 'create' do
@@ -38,7 +38,7 @@ describe 'usermacro' do
 
   context 'when hostmacro exists' do
     before :all do
-      @hostmacro = '{$' + gen_name 'hostmacro' + '}'
+      @hostmacro = '{$' + gen_name('hostmacro') + '}'
       @hostmacroid = zbx.usermacros.create(
         :macro => @hostmacro,
         :value => "public",
@@ -92,7 +92,7 @@ describe 'usermacro' do
 
       it "should create usermacro" do
         new_hostmacro_id = zbx.usermacros.create_or_update(
-          :macro => @hostmacro + "____1",
+          :macro => @hostmacro.gsub(/}/, "____1}"),
           :value => "public",
           :hostid => @templateid
         )
@@ -119,7 +119,7 @@ describe 'usermacro' do
   
   context 'when globalmacro not exists' do
     before do
-      @globalmacro = '{$' + gen_name 'globalmacro' + '}'
+      @globalmacro = '{$' + gen_name('globalmacro') + '}'
     end
 
     describe 'create_global' do
@@ -142,7 +142,7 @@ describe 'usermacro' do
 
   context 'when globalmacro exists' do
     before :all do
-      @globalmacro = '{$' + gen_name 'globalmacro' + '}'
+      @globalmacro = '{$' + gen_name('globalmacro') + '}'
       @globalmacroid = zbx.usermacros.create_global(
         :macro => @globalmacro,
         :value => "public",

--- a/spec/usermacro.rb
+++ b/spec/usermacro.rb
@@ -15,7 +15,7 @@ describe 'usermacro' do
 
   context 'when hostmacro not exists' do
     before do
-      @hostmacro = gen_name 'hostmacro'
+      @hostmacro = '{$' + gen_name 'hostmacro' + '}'
     end
 
     describe 'create' do
@@ -38,7 +38,7 @@ describe 'usermacro' do
 
   context 'when hostmacro exists' do
     before :all do
-      @hostmacro = gen_name 'hostmacro'
+      @hostmacro = '{$' + gen_name 'hostmacro' + '}'
       @hostmacroid = zbx.usermacros.create(
         :macro => @hostmacro,
         :value => "public",
@@ -119,7 +119,7 @@ describe 'usermacro' do
   
   context 'when globalmacro not exists' do
     before do
-      @globalmacro = gen_name 'globalmacro'
+      @globalmacro = '{$' + gen_name 'globalmacro' + '}'
     end
 
     describe 'create_global' do
@@ -142,7 +142,7 @@ describe 'usermacro' do
 
   context 'when globalmacro exists' do
     before :all do
-      @globalmacro = gen_name 'globalmacro'
+      @globalmacro = '{$' + gen_name 'globalmacro' + '}'
       @globalmacroid = zbx.usermacros.create_global(
         :macro => @globalmacro,
         :value => "public",


### PR DESCRIPTION
Added a usermacro spec and updated the usermacros class to get all tests passing for both host and global macros. Resolves #61

This not only fixes update() and update_global(), but also fixes the following methods for usermacros:
- get_id()
- get_id_global()
- get_full_data()
- get_full_data_global()
- delete()
- delete_global()
- get_or_create()
- get_or_create_global()
- create_or_update()
- create_or_update_global()
