### PR TITLE
#64 updated to json 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ rvm:
   - 2.0
   - 2.1
   - 2.2
+  - 2.3
+gemfile:
+  - Gemfile
+  - json-1.x.Gemfile
 dist: trusty
 sudo: required
 
@@ -29,3 +33,9 @@ before_script:
   - echo "$(curl -fsSL https://gist.githubusercontent.com/evtuhovich/9544441/raw/d661863063b76cc8e2599bc44d8595b1f86ece38/zabbix)" | sudo tee /etc/zabbix/web/zabbix.conf.php
   - sudo service apache2 restart
 script: "ZABBIX_HOST_URL=http://localhost/zabbix/api_jsonrpc.php bundle exec rspec spec/*"
+
+matrix:
+  exclude:
+    # json 2.x requires ruby 2.x
+    - rvm: 1.9.3
+      gemfile: json-1.x.Gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source 'https://rubygems.org'
 
-gem "rspec"
-gem "rake"
-gem "json"
+gemspec

--- a/json-1.x.Gemfile
+++ b/json-1.x.Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'json', '~> 1.8'
+gem 'rspec'

--- a/json-1.x.Gemfile.lock
+++ b/json-1.x.Gemfile.lock
@@ -1,15 +1,8 @@
-PATH
-  remote: .
-  specs:
-    zabbixapi (2.4.9)
-      json
-
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.2.5)
-    json (2.0.3)
-    rake (12.0.0)
+    json (1.8.5)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -28,9 +21,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  rake
+  json (~> 1.8)
   rspec
-  zabbixapi!
 
 BUNDLED WITH
    1.12.5

--- a/zabbixapi.gemspec
+++ b/zabbixapi.gemspec
@@ -12,7 +12,10 @@ Gem::Specification.new do |s|
   s.description = %q{Allows you to work with zabbix api from ruby.}
   s.licenses    = %w(MIT)
 
-  s.add_dependency('json', '~> 1.6', '>= 1.6.0')
+  s.add_runtime_dependency 'json'
+
+  s.add_development_dependency 'rake'
+  s.add_development_dependency 'rspec'
 
   s.rubyforge_project = "zabbixapi"
 


### PR DESCRIPTION
This allows other gems to depend on zabbixapi that use json 1.x or json 2.x

I cant find anywhere the difference between json 1.x and 2.x

I cant get the specs to work on master or this branch, but an idea for testing this would be multiple gemfiles in travis. `Gemfile.lock` specifying json `~> 2.0` and `json-1.x.Gemfile.lock` specifying json `~> 1.8`.