### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,7 +508,7 @@ zbx.scripts.update(
   :httptestid => zbx.scripts.get_id(:name => 'Hostname'),
   :execute_on => 0
 )
-#You can check script:
+# You can check script:
 puts zbx.scripts.get_full_data(:name => 'Hostname')
 
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
