### PR TITLE
Add timeout for http.open_timeout

### DIFF
--- a/lib/zabbixapi/client.rb
+++ b/lib/zabbixapi/client.rb
@@ -86,6 +86,7 @@ class ZabbixApi
         http.verify_mode = OpenSSL::SSL::VERIFY_NONE
       end
 
+      http.open_timeout = timeout
       http.read_timeout = timeout
 
       request = Net::HTTP::Post.new(uri.request_uri)


### PR DESCRIPTION
Relating to #74, noticed that there was no timeout set for [open_timeout](https://ruby-doc.org/stdlib-2.4.1/libdoc/net/http/rdoc/Net/HTTP.html#open_timeout). 

If url passed in options is not a valid zabbix ip, then user need to wait for 60 seconds (Net::HTTP default) as of now. This PR will set timeout to that as well as read_timeout. 

Edit: maybe two timeouts should be separate options. Let me know if that's the case