### PR TITLE
Hide password when raising error

### DIFF
--- a/lib/zabbixapi/client.rb
+++ b/lib/zabbixapi/client.rb
@@ -113,7 +113,7 @@ class ZabbixApi
       parsed_body = JSON.parse(body)
 
       # If password is in body hide it
-      parsed_body['params']['password'] = '***' if parsed_body['params'].has_key? 'password'
+      parsed_body['params']['password'] = '***' if parsed_body['params'].key? 'password'
 
       JSON.pretty_unparse(parsed_body)
     end

--- a/lib/zabbixapi/client.rb
+++ b/lib/zabbixapi/client.rb
@@ -113,7 +113,7 @@ class ZabbixApi
       parsed_body = JSON.parse(body)
 
       # If password is in body hide it
-      parsed_body['params']['password'] = '***' if parsed_body['params'].key? 'password'
+      parsed_body['params']['password'] = '***' if parsed_body['params'].is_a?(Hash) && parsed_body['params'].key?('password')
 
       JSON.pretty_unparse(parsed_body)
     end

--- a/lib/zabbixapi/client.rb
+++ b/lib/zabbixapi/client.rb
@@ -105,8 +105,17 @@ class ZabbixApi
     def _request(body)
       puts "[DEBUG] Send request: #{body}" if @options[:debug]
       result = JSON.parse(http_request(body))
-      raise ApiError.new("Server answer API error\n #{JSON.pretty_unparse(result['error'])}\n on request:\n #{JSON.pretty_unparse(JSON.parse(body))}", result) if result['error']
+      raise ApiError.new("Server answer API error\n #{JSON.pretty_unparse(result['error'])}\n on request:\n #{pretty_body(body)}", result) if result['error']
       result['result']
+    end
+
+    def pretty_body(body)
+      parsed_body = JSON.parse(body)
+
+      # If password is in body hide it
+      parsed_body['params']['password'] = '***' if parsed_body['params'].has_key? 'password'
+
+      JSON.pretty_unparse(parsed_body)
     end
 
     # Execute Zabbix API requests and return response


### PR DESCRIPTION
Without this I would get this,

```
zabbixapi/lib/zabbixapi/client.rb:108:in `_request': Server answer API error (ZabbixApi::ApiError)
 {
  "code": -32602,
  "message": "Invalid params.",
  "data": "Login name or password is incorrect."
}
 on request:
 {
  "method": "user.login",
  "params": {
    "user": "Admin",
    "password": "zabbix"
  },
  "id": 55213,
  "jsonrpc": "2.0"
}
```

With this change its now,

```
zabbixapi/lib/zabbixapi/client.rb:108:in `_request': Server answer API error (ZabbixApi::ApiError)
 {
  "code": -32602,
  "message": "Invalid params.",
  "data": "Login name or password is incorrect."
}
 on request:
 {
  "method": "user.login",
  "params": {
    "user": "Admin",
    "password": "***"
  },
  "id": 69191,
  "jsonrpc": "2.0"
}
```