### PR TITLE
Feature: add support for Discovery Rules (`drule` API)

### DIFF
--- a/examples/DiscoveryRule.md
+++ b/examples/DiscoveryRule.md
@@ -1,0 +1,22 @@
+# Discovery Rule
+
+This example assumes you have already initialized and connected the ZabbixApi.
+
+For more information and available properties please refer to the Zabbix API documentation for Actions:
+[https://www.zabbix.com/documentation/3.2/manual/api/reference/drule](https://www.zabbix.com/documentation/3.2/manual/api/reference/drule)
+
+## Create Discovery Rule
+```ruby
+zbx.drules.create(
+  :name => 'zabbix agent discovery',
+  :delay => '1800', # discover new machines every 30min
+  :status => '0', # action is enabled
+  :iprange => '192.168.0.0/24', # iprange to discover zabbix agents in
+  :dchecks => [{
+    :type => '9', # zabbix agent
+    :uniq => '0', # (default) do not use this check as a uniqueness criteria
+    :key_ => 'system.hostname',
+    :ports => '10050',
+  }],
+)
+```

--- a/lib/zabbixapi.rb
+++ b/lib/zabbixapi.rb
@@ -28,6 +28,7 @@ require 'zabbixapi/classes/usergroups'
 require 'zabbixapi/classes/usermacros'
 require 'zabbixapi/classes/users'
 require 'zabbixapi/classes/valuemaps'
+require 'zabbixapi/classes/drules'
 
 class ZabbixApi
   # @return [ZabbixApi::Client]
@@ -160,5 +161,10 @@ class ZabbixApi
   # @return [ZabbixApi::ValueMaps]
   def valuemaps
     @valuemaps ||= ValueMaps.new(@client)
+  end
+
+  # @return [ZabbixApi::Drules]
+  def drules
+    @drules ||= Drules.new(@client)
   end
 end

--- a/lib/zabbixapi/classes/drules.rb
+++ b/lib/zabbixapi/classes/drules.rb
@@ -1,0 +1,55 @@
+class ZabbixApi
+  class Drules < Basic
+    # The method name used for interacting with Drules via Zabbix API
+    #
+    # @return [String]
+    def method_name
+      'drule'
+    end
+
+    # The id field name used for identifying specific Drule objects via Zabbix API
+    #
+    # @return [String]
+    def indentify
+      'name'
+    end
+
+    # The default options used when creating Drule objects via Zabbix API
+    #
+    # @return [Hash]
+    def default_options
+      {
+        name: nil,
+        iprange: nil,
+        delay: 3600,
+        status: 0,
+      }
+    end
+
+    # Get or Create Drule object using Zabbix API
+    #
+    # @param data [Hash] Needs to include name to properly identify Drule via Zabbix API
+    # @raise [ApiError] Error returned when there is a problem with the Zabbix API call.
+    # @raise [HttpError] Error raised when HTTP status from Zabbix Server response is not a 200 OK.
+    # @return [Integer] Zabbix object id
+    def get_or_create(data)
+      log "[DEBUG] Call get_or_create with parameters: #{data.inspect}"
+
+      unless (id = get_id(name: data[:name]))
+        id = create(data)
+      end
+      id
+    end
+
+    # Create or update Drule object using Zabbix API
+    #
+    # @param data [Hash] Needs to include name to properly identify Drules via Zabbix API
+    # @raise [ApiError] Error returned when there is a problem with the Zabbix API call.
+    # @raise [HttpError] Error raised when HTTP status from Zabbix Server response is not a 200 OK.
+    # @return [Integer] Zabbix object id
+    def create_or_update(data)
+      druleid = get_id(name: data[:name])
+      druleid ? update(data.merge(druleid: druleid)) : create(data)
+    end
+  end
+end

--- a/spec/drule.rb
+++ b/spec/drule.rb
@@ -1,0 +1,50 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+describe 'drule' do
+  before do
+    @drulename = gen_name 'drule'
+    @usergroupid = zbx.usergroups.create(:name => gen_name('usergroup'))
+    @dcheckdata = [{
+      :type => '9', # zabbix agent
+      :uniq => '0', # (default) do not use this check as a uniqueness criteria
+      :key_ => 'system.hostname',
+      :ports => '10050',
+    }]
+    @druledata = {
+      :name => @drulename,
+      :delay => '60',
+      :status => '0', # action is enabled
+      :iprange => '192.168.0.0/24', # iprange to discover zabbix agents in
+      :dchecks => @dcheckdata,
+    }
+  end
+
+  context 'when not exists' do
+    describe 'create' do
+      it 'should return integer id' do
+        druleid = zbx.drules.create(@druledata)
+        expect(druleid).to be_kind_of(Integer)
+      end
+    end
+  end
+
+  context 'when exists' do
+    before do
+      @druleid = zbx.drules.create(@druledata)
+    end
+
+    describe 'create_or_update' do
+      it 'should return id' do
+        expect(zbx.drules.create_or_update(@druledata)).to eq @druleid
+      end
+    end
+
+    describe 'delete' do
+      it 'should return id' do
+        expect(zbx.drules.delete(@druleid)).to eq @druleid
+      end
+    end
+  end
+end


### PR DESCRIPTION
Zabbix has a network discovery rule API. In combination with discovery actions, it is possible to setup a working auto-registration of zabbix-agents which get updated, if your agent is already registered.

We're using this kind of setup to automatically assign different Zabbix Templates to already known hosts when their metadata got changed.

This PR implements required `drule` API.