### PR TITLE
Add nominal support for zabbix v 4.0

### DIFF
--- a/lib/zabbixapi/client.rb
+++ b/lib/zabbixapi/client.rb
@@ -51,7 +51,7 @@ class ZabbixApi
         @proxy_port = @proxy_uri.port
         @proxy_user, @proxy_pass = @proxy_uri.userinfo.split(/:/) if @proxy_uri.userinfo
       end
-      unless api_version =~ /(2\.4|3\.[02])\.\d+/
+      unless api_version =~ /(2\.4|3\.[02]|4\.0)\.\d+/
         raise ApiError.new("Zabbix API version: #{api_version} is not support by this version of zabbixapi")
       end
       @auth_hash = auth


### PR DESCRIPTION
This just slaps 4.0 in the list of supported versions. I've not tested it beyond my immediate needs but it works well enough for me.