### PR TITLE
Add Zabbix 4.2 support

### DIFF
--- a/lib/zabbixapi/client.rb
+++ b/lib/zabbixapi/client.rb
@@ -53,7 +53,7 @@ class ZabbixApi
         @proxy_user, @proxy_pass = @proxy_uri.userinfo.split(/:/) if @proxy_uri.userinfo
       end
 
-      unless api_version =~ /(2\.4|3\.[024]|4\.0)\.\d+/
+      unless api_version =~ /(2\.4|3\.[024]|4\.[02])\.\d+/
         raise ApiError.new("Zabbix API version: #{api_version} is not support by this version of zabbixapi")
       end
 


### PR DESCRIPTION
This closes #95.
I've tested in in voxpopuli/zabbix and look like this fix works.