### PR TITLE
Allow only for Zabbix API 4.0 or 4.4

### DIFF
--- a/lib/zabbixapi/client.rb
+++ b/lib/zabbixapi/client.rb
@@ -52,7 +52,7 @@ class ZabbixApi
         @proxy_port = @proxy_uri.port
         @proxy_user, @proxy_pass = @proxy_uri.userinfo.split(/:/) if @proxy_uri.userinfo
       end
-      unless api_version =~ %r{^4.[0|2]\.\d+$}
+      unless api_version =~ %r{^4.[0|4]\.\d+$}
         puts "[WARN] Zabbix API version: #{api_version} is not supported by this version of zabbixapi"
       end
 


### PR DESCRIPTION
Drop Zabbix API 4.2 as this version is EOL, Allow for 4.4 as two latest versions are supported.  
Relates to #108 