### PR TITLE
local_docker_test_stack: test/bin/local_docker_stack can be used to s…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /test/tmp/
 /test/version_tmp/
 /tmp/
+Gemfile.lock
 
 ## Specific to RubyMotion:
 .dat*

--- a/test/bin/local_docker_stack
+++ b/test/bin/local_docker_stack
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# zabbixapi
+# 
+# Use to deploy local zabbix stack for testing
+
+base_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+stack_deploy_output=$(docker stack deploy --compose-file ${base_dir}/../docker_compose/test_docker_stack.yml zabbix)
+echo ${stack_deploy_output} | grep 'this node is not a swarm manager' /dev/null
+rc=$?
+
+if [[ ${rc} == 0 ]] ; then
+  docker swarm init
+  docker stack deploy --compose-file ${base_dir}/../docker_compose/test_docker_stack.yml zabbix
+fi
+
+echo 'Use the following to obtain informaiton about the stack'
+echo 'docker stack services zabbix'
+echo 'docker stack rm zabbix'
+echo 'docker network inspect zabbix_zabbix'
+echo 'docker container ls | grep zabbix_'
+echo 'docker logs ${container_name}'
+echo 'bundle exec rspec spec/*'
+echo 'open browser: http://localhost:8080'
+echo '  Username: Admin'
+echo '  Password: zabbix'

--- a/test/docker_compose/test_docker_stack.yml
+++ b/test/docker_compose/test_docker_stack.yml
@@ -1,0 +1,50 @@
+# Postgres, Zabbix Server and Zabbix Frontend stack deployment for testing spec tests locally
+# https://www.zabbix.com/container_images
+
+version: '3.8'
+
+services:
+  db:
+    image: postgres
+    restart: always
+    environment:
+      POSTGRES_PASSWORD: password
+      POSTGRES_USER: zabbix
+      POSTGRES_DB: zabbix
+    networks:
+      zabbix:
+    ports:
+      - "5432:5432"
+  server:
+    image: zabbix/zabbix-server-pgsql:alpine-4.0-latest
+    depends_on:
+      - db
+    environment:
+      DB_SERVER_HOST: db
+      POSTGRES_USER: zabbix
+      POSTGRES_PASSWORD: password
+    networks:
+      zabbix:
+    ports:
+      - 10051:10051
+  frontend:
+    image: zabbix/zabbix-web-apache-pgsql:alpine-4.0-latest
+    depends_on:
+      - db
+      - zabbix_server
+    environment:
+      DB_SERVER_HOST: db
+      POSTGRES_USER: zabbix
+      POSTGRES_PASSWORD: password
+      ZBX_SERVER_HOST: server
+      PHP_TZ: "US/Eastern"
+    networks:
+      zabbix:
+    ports:
+      - "8080:8080"
+networks:
+  zabbix:
+    ipam:
+      driver: default
+      config:
+        - subnet: "172.16.238.0/24"


### PR DESCRIPTION
test/bin/local_docker_stack can be used to stand up a local dockerized Zabbix frontend, server and postgres db stack to test and validate the zabbixapi gem

Signed-off-by: Kevin J. Smith <kevin.j.smith2@cerner.com>