### PR TITLE
Re-add the Client.logout method

### DIFF
--- a/lib/zabbixapi/client.rb
+++ b/lib/zabbixapi/client.rb
@@ -49,6 +49,7 @@ class ZabbixApi
       api_request(
 	 :method => 'user.logout',
 	 :params => []
+      )
     end
 
     # Initializes a new Client object

--- a/lib/zabbixapi/client.rb
+++ b/lib/zabbixapi/client.rb
@@ -41,6 +41,16 @@ class ZabbixApi
       return ! @options || @options[:debug]
     end
 
+    # Log out from the Zabbix Server
+    #
+    # @return [Boolean]
+    #
+    def logout
+      api_request(
+	 :method => 'user.logout',
+	 :params => []
+    end
+
     # Initializes a new Client object
     #
     # @param options [Hash]


### PR DESCRIPTION
Back in commit ac4e854d4b34906e8f3919dcad10d52fcba9b65d the Client.logout method was inexplicably removed without comment.  Without this call zabbix will accrue dead sessions which will slow the server down over time.  This re-adds the method.